### PR TITLE
Change staging endpoint

### DIFF
--- a/WordpressSync/endpoints.json
+++ b/WordpressSync/endpoints.json
@@ -37,7 +37,7 @@
           "Owner": "cagov",
           "Repo": "drought.ca.gov",
           "Branch": "staging",
-          "ConfigPath": "wordpress/wordpress-to-github.config.json"
+          "ConfigPath": "odi-publishing/wordpress-to-github.config.json"
         }
       },
       {


### PR DESCRIPTION
Changes the endpoint for the `staging` branch of Drought, corresponding to changes in cagov/drought.ca.gov#232. The location of the wordpress-to-github.config.json file has moved.