### PR TITLE
Change main-test-pantheon endpoint configPath

### DIFF
--- a/WordpressSync/endpoints.json
+++ b/WordpressSync/endpoints.json
@@ -53,7 +53,7 @@
           "Owner": "cagov",
           "Repo": "drought.ca.gov",
           "Branch": "main-test-pantheon",
-          "ConfigPath": "wordpress/wordpress-to-github.config.json"
+          "ConfigPath": "odi-publishing/wordpress-to-github.config.json"
         }
       }
     ]


### PR DESCRIPTION
Need to change this configuration to synchronize the `main-test-pantheon` branch of drought.ca.gov with `main`. 

The location of the wordpress-to-github.config.json will change to match `main`.